### PR TITLE
Reduce potential for hangs in pthread_create/14-1 and pthread_join/6-3

### DIFF
--- a/conformance/interfaces/pthread_create/14-1.c
+++ b/conformance/interfaces/pthread_create/14-1.c
@@ -102,7 +102,7 @@
 /***********************************    Real Test   *****************************************/
 /********************************************************************************************/
 
-char do_it=1;
+volatile char do_it=1;
 char woken=0;
 unsigned long count_ope=0;
 #ifdef WITH_SYNCHRO
@@ -310,6 +310,10 @@ int main (int argc, char * argv[])
 	/* Now stop the threads and join them */
 	do { do_it=0; }
 	while (do_it);
+#ifdef WITH_SYNCHRO
+	sem_post(&semsig1);
+	sem_post(&semsig2);
+#endif
 	
 	if ((ret = pthread_join(th_sig1, NULL)))
 	{ UNRESOLVED(ret, "Signal 1 sender thread join failed"); }

--- a/conformance/interfaces/pthread_join/6-3.c
+++ b/conformance/interfaces/pthread_join/6-3.c
@@ -91,7 +91,7 @@
 /***********************************    Test cases  *****************************************/
 /********************************************************************************************/
 
-char do_it = 1;
+volatile char do_it = 1;
 unsigned long count_ope = 0;
 #ifdef WITH_SYNCHRO
 sem_t semsig1;
@@ -347,6 +347,10 @@ int main ( int argc, char * argv[] )
 		do_it = 0;
 	}
 	while ( do_it );
+#ifdef WITH_SYNCHRO
+	sem_post(&semsig1);
+	sem_post(&semsig2);
+#endif
 
 
 	if ( ( ret = pthread_join( th_sig1, NULL ) ) )


### PR DESCRIPTION
These tests use a global variable, `do_it`, to signal the intent to end thread processing.  This variable should be `volatile`.  More egregiously, there is a race between checking this (unsynchronised) variable and a blocking `sem_wait()` in some threads.  When the race occurs, the programs appear to block forever as they try to exit.
